### PR TITLE
Add basic Compose MVVM app structure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.ecodeli.client"
+    compileSdk = 33
+
+    defaultConfig {
+        applicationId = "com.ecodeli.client"
+        minSdk = 24
+        targetSdk = 33
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
+
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.10.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.compose.ui:ui:1.5.1")
+    implementation("androidx.compose.material:material:1.5.1")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.5.1")
+    implementation("androidx.navigation:navigation-compose:2.6.0")
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest package="com.ecodeli.client" xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="EcoDeli"
+        android:icon="@mipmap/ic_launcher"
+        android:theme="@style/Theme.EcoDeliClient">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/ecodeli/client/MainActivity.kt
+++ b/app/src/main/java/com/ecodeli/client/MainActivity.kt
@@ -1,0 +1,27 @@
+package com.ecodeli.client
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.ui.Modifier
+import com.ecodeli.client.navigation.AppNavHost
+import com.ecodeli.client.ui.theme.EcoDeliTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            EcoDeliTheme {
+                Scaffold(
+                    topBar = { TopAppBar(title = { Text("EcoDeli") }) }
+                ) { innerPadding ->
+                    AppNavHost(modifier = Modifier.padding(innerPadding))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/di/Injector.kt
+++ b/app/src/main/java/com/ecodeli/client/di/Injector.kt
@@ -1,0 +1,15 @@
+package com.ecodeli.client.di
+
+import android.content.Context
+import com.ecodeli.client.network.AuthInterceptor
+import com.ecodeli.client.network.RetrofitClient
+import com.ecodeli.client.repository.AuthRepository
+import com.ecodeli.client.repository.UserPreferences
+
+object Injector {
+    fun provideAuthRepository(context: Context): AuthRepository {
+        val prefs = UserPreferences(context)
+        val api = RetrofitClient.createApiService(AuthInterceptor(prefs))
+        return AuthRepository(api, prefs)
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/model/LoginRequest.kt
+++ b/app/src/main/java/com/ecodeli/client/model/LoginRequest.kt
@@ -1,0 +1,6 @@
+package com.ecodeli.client.model
+
+data class LoginRequest(
+    val email: String,
+    val password: String
+)

--- a/app/src/main/java/com/ecodeli/client/model/LoginResponse.kt
+++ b/app/src/main/java/com/ecodeli/client/model/LoginResponse.kt
@@ -1,0 +1,8 @@
+package com.ecodeli.client.model
+
+import com.google.gson.annotations.SerializedName
+
+data class LoginResponse(
+    val token: String,
+    val name: String
+)

--- a/app/src/main/java/com/ecodeli/client/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/ecodeli/client/navigation/AppNavHost.kt
@@ -1,0 +1,35 @@
+package com.ecodeli.client.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.ecodeli.client.screens.HomeScreen
+import com.ecodeli.client.screens.LoginScreen
+
+object Routes {
+    const val LOGIN = "login"
+    const val HOME = "home"
+}
+
+@Composable
+fun AppNavHost(modifier: Modifier = Modifier, navController: NavHostController = rememberNavController()) {
+    NavHost(
+        navController = navController,
+        startDestination = Routes.LOGIN,
+        modifier = modifier
+    ) {
+        composable(Routes.LOGIN) {
+            LoginScreen(onLoginSuccess = {
+                navController.navigate(Routes.HOME) {
+                    popUpTo(Routes.LOGIN) { inclusive = true }
+                }
+            })
+        }
+        composable(Routes.HOME) {
+            HomeScreen()
+        }
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/network/ApiService.kt
+++ b/app/src/main/java/com/ecodeli/client/network/ApiService.kt
@@ -1,0 +1,11 @@
+package com.ecodeli.client.network
+
+import com.ecodeli.client.model.LoginRequest
+import com.ecodeli.client.model.LoginResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface ApiService {
+    @POST("login")
+    suspend fun login(@Body request: LoginRequest): LoginResponse
+}

--- a/app/src/main/java/com/ecodeli/client/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/ecodeli/client/network/AuthInterceptor.kt
@@ -1,0 +1,18 @@
+package com.ecodeli.client.network
+
+import com.ecodeli.client.repository.UserPreferences
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthInterceptor(private val prefs: UserPreferences) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val token = runBlocking { prefs.getToken() }
+        val newRequest = if (token != null) {
+            chain.request().newBuilder()
+                .addHeader("Authorization", "Bearer $token")
+                .build()
+        } else chain.request()
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/network/RetrofitClient.kt
+++ b/app/src/main/java/com/ecodeli/client/network/RetrofitClient.kt
@@ -1,0 +1,22 @@
+package com.ecodeli.client.network
+
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object RetrofitClient {
+    private const val BASE_URL = "http://10.0.2.2:8000/api/"
+
+    fun createApiService(interceptor: AuthInterceptor): ApiService {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(interceptor)
+            .build()
+
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ApiService::class.java)
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/repository/AuthRepository.kt
+++ b/app/src/main/java/com/ecodeli/client/repository/AuthRepository.kt
@@ -1,0 +1,11 @@
+package com.ecodeli.client.repository
+
+import com.ecodeli.client.model.LoginRequest
+import com.ecodeli.client.network.ApiService
+
+class AuthRepository(private val api: ApiService, private val prefs: UserPreferences) {
+    suspend fun login(email: String, password: String) = api.login(LoginRequest(email, password)).also {
+        prefs.saveToken(it.token)
+        prefs.saveName(it.name)
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/repository/UserPreferences.kt
+++ b/app/src/main/java/com/ecodeli/client/repository/UserPreferences.kt
@@ -1,0 +1,32 @@
+package com.ecodeli.client.repository
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+class UserPreferences(private val context: Context) {
+    companion object {
+        private val Context.dataStore by preferencesDataStore("user_prefs")
+        val TOKEN_KEY = stringPreferencesKey("token")
+        val NAME_KEY = stringPreferencesKey("name")
+    }
+
+    suspend fun saveToken(token: String) {
+        context.dataStore.edit { it[TOKEN_KEY] = token }
+    }
+
+    suspend fun getToken(): String? {
+        return context.dataStore.data.map { it[TOKEN_KEY] }.first()
+    }
+
+    suspend fun saveName(name: String) {
+        context.dataStore.edit { it[NAME_KEY] = name }
+    }
+
+    suspend fun getName(): String? {
+        return context.dataStore.data.map { it[NAME_KEY] }.first()
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ecodeli/client/screens/HomeScreen.kt
@@ -1,0 +1,28 @@
+package com.ecodeli.client.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.*
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.ecodeli.client.repository.UserPreferences
+
+@Composable
+fun HomeScreen() {
+    val context = LocalContext.current
+    val prefs = remember { UserPreferences(context) }
+    var name by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        name = prefs.getName() ?: ""
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "Bienvenue $name!")
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/screens/LoginScreen.kt
+++ b/app/src/main/java/com/ecodeli/client/screens/LoginScreen.kt
@@ -1,0 +1,58 @@
+package com.ecodeli.client.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ecodeli.client.di.Injector
+import com.ecodeli.client.viewmodel.AuthViewModel
+import com.ecodeli.client.viewmodel.AuthViewModelFactory
+
+@Composable
+fun LoginScreen(onLoginSuccess: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: AuthViewModel = viewModel(factory = AuthViewModelFactory(Injector.provideAuthRepository(context)))
+    val loginState by viewModel.loginState.collectAsState()
+
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text("Email") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = { viewModel.login(email, password) }, modifier = Modifier.fillMaxWidth()) {
+            Text("Login")
+        }
+        when (val state = loginState) {
+            is AuthViewModel.LoginState.Success -> {
+                LaunchedEffect(Unit) { onLoginSuccess() }
+            }
+            is AuthViewModel.LoginState.Error -> {
+                Text(text = state.message)
+            }
+            else -> {}
+        }
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/ui/theme/Color.kt
+++ b/app/src/main/java/com/ecodeli/client/ui/theme/Color.kt
@@ -1,0 +1,8 @@
+package com.ecodeli.client.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple200 = Color(0xFFBB86FC)
+val Purple500 = Color(0xFF6200EE)
+val Purple700 = Color(0xFF3700B3)
+val Teal200 = Color(0xFF03DAC5)

--- a/app/src/main/java/com/ecodeli/client/ui/theme/Shape.kt
+++ b/app/src/main/java/com/ecodeli/client/ui/theme/Shape.kt
@@ -1,0 +1,5 @@
+package com.ecodeli.client.ui.theme
+
+import androidx.compose.material.Shapes
+
+val Shapes = Shapes()

--- a/app/src/main/java/com/ecodeli/client/ui/theme/Theme.kt
+++ b/app/src/main/java/com/ecodeli/client/ui/theme/Theme.kt
@@ -1,0 +1,29 @@
+package com.ecodeli.client.ui.theme
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+
+private val DarkColorPalette = darkColors(
+    primary = Purple200,
+    primaryVariant = Purple700,
+    secondary = Teal200
+)
+
+private val LightColorPalette = lightColors(
+    primary = Purple500,
+    primaryVariant = Purple700,
+    secondary = Teal200
+)
+
+@Composable
+fun EcoDeliTheme(content: @Composable () -> Unit) {
+    val colors = LightColorPalette
+    MaterialTheme(
+        colors = colors,
+        typography = Typography,
+        shapes = Shapes,
+        content = content
+    )
+}

--- a/app/src/main/java/com/ecodeli/client/ui/theme/Typography.kt
+++ b/app/src/main/java/com/ecodeli/client/ui/theme/Typography.kt
@@ -1,0 +1,5 @@
+package com.ecodeli.client.ui.theme
+
+import androidx.compose.material.Typography
+
+val Typography = Typography()

--- a/app/src/main/java/com/ecodeli/client/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/ecodeli/client/viewmodel/AuthViewModel.kt
@@ -1,0 +1,33 @@
+package com.ecodeli.client.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ecodeli.client.repository.AuthRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class AuthViewModel(private val repo: AuthRepository) : ViewModel() {
+
+    private val _loginState = MutableStateFlow<LoginState>(LoginState.Empty)
+    val loginState: StateFlow<LoginState> = _loginState
+
+    fun login(email: String, password: String) {
+        viewModelScope.launch {
+            _loginState.value = LoginState.Loading
+            try {
+                val response = repo.login(email, password)
+                _loginState.value = LoginState.Success(response.name)
+            } catch (e: Exception) {
+                _loginState.value = LoginState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    sealed class LoginState {
+        object Empty : LoginState()
+        object Loading : LoginState()
+        data class Success(val name: String) : LoginState()
+        data class Error(val message: String) : LoginState()
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/viewmodel/AuthViewModelFactory.kt
+++ b/app/src/main/java/com/ecodeli/client/viewmodel/AuthViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.ecodeli.client.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.ecodeli.client.repository.AuthRepository
+
+class AuthViewModelFactory(private val repository: AuthRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(AuthViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return AuthViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.0.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20")
+    }
+}
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m
+android.useAndroidX=true
+kotlin.code.style=official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = "EcoDeliClient"
+include(":app")


### PR DESCRIPTION
## Summary
- set up Gradle scripts and app module for Compose
- implement MVVM foundation with repository, ViewModel, and DataStore
- configure Retrofit with an auth interceptor
- add login and home screens with navigation
- include a persistent app bar in `MainActivity`

## Testing
- `./gradlew --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687554ee4be88331b7b395105f7982ea