### PR TITLE
Ajout des écrans d'annonces

### DIFF
--- a/app/src/main/java/com/ecodeli/client/di/Injector.kt
+++ b/app/src/main/java/com/ecodeli/client/di/Injector.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.ecodeli.client.network.AuthInterceptor
 import com.ecodeli.client.network.RetrofitClient
 import com.ecodeli.client.repository.AuthRepository
+import com.ecodeli.client.repository.AnnonceRepository
 import com.ecodeli.client.repository.UserPreferences
 
 object Injector {
@@ -11,5 +12,11 @@ object Injector {
         val prefs = UserPreferences(context)
         val api = RetrofitClient.createApiService(AuthInterceptor(prefs))
         return AuthRepository(api, prefs)
+    }
+
+    fun provideAnnonceRepository(context: Context): AnnonceRepository {
+        val prefs = UserPreferences(context)
+        val api = RetrofitClient.createApiService(AuthInterceptor(prefs))
+        return AnnonceRepository(api)
     }
 }

--- a/app/src/main/java/com/ecodeli/client/model/Annonce.kt
+++ b/app/src/main/java/com/ecodeli/client/model/Annonce.kt
@@ -1,0 +1,16 @@
+package com.ecodeli.client.model
+
+import com.google.gson.annotations.SerializedName
+
+data class Annonce(
+    val id: Int,
+    val titre: String,
+    @SerializedName("ville_depart") val villeDepart: String,
+    @SerializedName("ville_arrivee") val villeArrivee: String,
+    val type: String?,
+    @SerializedName("date_depot") val dateDepot: String,
+    val description: String?,
+    val prix: Double?,
+    val distance: Double?,
+    @SerializedName("transport_souhaite") val transportSouhaite: String?
+)

--- a/app/src/main/java/com/ecodeli/client/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/ecodeli/client/navigation/AppNavHost.kt
@@ -7,11 +7,18 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.ecodeli.client.screens.HomeScreen
+import com.ecodeli.client.screens.AnnonceListScreen
+import com.ecodeli.client.screens.AnnonceDetailScreen
 import com.ecodeli.client.screens.LoginScreen
+import androidx.navigation.compose.navArgument
+import androidx.navigation.NavType
+import com.google.gson.Gson
 
 object Routes {
     const val LOGIN = "login"
     const val HOME = "home"
+    const val ANNONCES = "annonces"
+    const val ANNONCE_DETAIL = "annonceDetail"
 }
 
 @Composable
@@ -23,13 +30,27 @@ fun AppNavHost(modifier: Modifier = Modifier, navController: NavHostController =
     ) {
         composable(Routes.LOGIN) {
             LoginScreen(onLoginSuccess = {
-                navController.navigate(Routes.HOME) {
+                navController.navigate(Routes.ANNONCES) {
                     popUpTo(Routes.LOGIN) { inclusive = true }
                 }
             })
         }
         composable(Routes.HOME) {
             HomeScreen()
+        }
+        composable(Routes.ANNONCES) {
+            AnnonceListScreen(onAnnonceSelected = { annonce ->
+                val annonceJson = Gson().toJson(annonce)
+                navController.navigate("${Routes.ANNONCE_DETAIL}/$annonceJson")
+            })
+        }
+        composable(
+            route = "${Routes.ANNONCE_DETAIL}/{annonce}",
+            arguments = listOf(navArgument("annonce") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val annonceJson = backStackEntry.arguments?.getString("annonce")
+            val annonce = Gson().fromJson(annonceJson, com.ecodeli.client.model.Annonce::class.java)
+            AnnonceDetailScreen(annonce)
         }
     }
 }

--- a/app/src/main/java/com/ecodeli/client/network/ApiService.kt
+++ b/app/src/main/java/com/ecodeli/client/network/ApiService.kt
@@ -2,10 +2,15 @@ package com.ecodeli.client.network
 
 import com.ecodeli.client.model.LoginRequest
 import com.ecodeli.client.model.LoginResponse
+import com.ecodeli.client.model.Annonce
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface ApiService {
     @POST("login")
     suspend fun login(@Body request: LoginRequest): LoginResponse
+
+    @GET("client/annonces")
+    suspend fun getAnnonces(): List<Annonce>
 }

--- a/app/src/main/java/com/ecodeli/client/repository/AnnonceRepository.kt
+++ b/app/src/main/java/com/ecodeli/client/repository/AnnonceRepository.kt
@@ -1,0 +1,8 @@
+package com.ecodeli.client.repository
+
+import com.ecodeli.client.model.Annonce
+import com.ecodeli.client.network.ApiService
+
+class AnnonceRepository(private val api: ApiService) {
+    suspend fun getAnnonces(): List<Annonce> = api.getAnnonces()
+}

--- a/app/src/main/java/com/ecodeli/client/screens/AnnonceDetailScreen.kt
+++ b/app/src/main/java/com/ecodeli/client/screens/AnnonceDetailScreen.kt
@@ -1,0 +1,28 @@
+package com.ecodeli.client.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.ecodeli.client.model.Annonce
+
+@Composable
+fun AnnonceDetailScreen(annonce: Annonce) {
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(text = annonce.titre)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(text = "${'$'}{annonce.villeDepart} → ${'$'}{annonce.villeArrivee}")
+        annonce.type?.let { Text(text = it) }
+        Text(text = annonce.dateDepot)
+        annonce.description?.let { Text(text = it) }
+        annonce.prix?.let { Text(text = "Prix: ${'$'}it €") }
+        annonce.distance?.let { Text(text = "Distance: ${'$'}it km") }
+        annonce.transportSouhaite?.let { Text(text = "Transport: ${'$'}it") }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = { /* TODO reservation */ }, modifier = Modifier.fillMaxWidth()) {
+            Text("Réserver")
+        }
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/screens/AnnonceListScreen.kt
+++ b/app/src/main/java/com/ecodeli/client/screens/AnnonceListScreen.kt
@@ -1,0 +1,60 @@
+package com.ecodeli.client.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ecodeli.client.di.Injector
+import com.ecodeli.client.model.Annonce
+import com.ecodeli.client.viewmodel.AnnonceViewModel
+import com.ecodeli.client.viewmodel.AnnonceViewModelFactory
+
+@Composable
+fun AnnonceListScreen(onAnnonceSelected: (Annonce) -> Unit) {
+    val context = LocalContext.current
+    val viewModel: AnnonceViewModel = viewModel(factory = AnnonceViewModelFactory(Injector.provideAnnonceRepository(context)))
+    val state by viewModel.uiState.collectAsState()
+
+    when (val s = state) {
+        is AnnonceViewModel.AnnonceState.Loading -> {
+            Box(Modifier.fillMaxSize(), contentAlignment = androidx.compose.ui.Alignment.Center) {
+                Text("Chargement...")
+            }
+        }
+        is AnnonceViewModel.AnnonceState.Error -> {
+            Box(Modifier.fillMaxSize(), contentAlignment = androidx.compose.ui.Alignment.Center) {
+                Text("Erreur: ${'$'}{s.message}")
+            }
+        }
+        is AnnonceViewModel.AnnonceState.Success -> {
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(8.dp)) {
+                items(s.annonces) { annonce ->
+                    AnnonceCard(annonce, onAnnonceSelected)
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AnnonceCard(annonce: Annonce, onClick: (Annonce) -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable { onClick(annonce) }.padding(8.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = annonce.titre)
+            Text(text = "${'$'}{annonce.villeDepart} → ${'$'}{annonce.villeArrivee}")
+            annonce.type?.let { Text(text = it) }
+            Text(text = annonce.dateDepot)
+        }
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/viewmodel/AnnonceViewModel.kt
+++ b/app/src/main/java/com/ecodeli/client/viewmodel/AnnonceViewModel.kt
@@ -1,0 +1,37 @@
+package com.ecodeli.client.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ecodeli.client.model.Annonce
+import com.ecodeli.client.repository.AnnonceRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class AnnonceViewModel(private val repo: AnnonceRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<AnnonceState>(AnnonceState.Loading)
+    val uiState: StateFlow<AnnonceState> = _uiState
+
+    init {
+        fetchAnnonces()
+    }
+
+    fun fetchAnnonces() {
+        viewModelScope.launch {
+            _uiState.value = AnnonceState.Loading
+            try {
+                val annonces = repo.getAnnonces()
+                _uiState.value = AnnonceState.Success(annonces)
+            } catch (e: Exception) {
+                _uiState.value = AnnonceState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    sealed class AnnonceState {
+        object Loading : AnnonceState()
+        data class Success(val annonces: List<Annonce>) : AnnonceState()
+        data class Error(val message: String) : AnnonceState()
+    }
+}

--- a/app/src/main/java/com/ecodeli/client/viewmodel/AnnonceViewModelFactory.kt
+++ b/app/src/main/java/com/ecodeli/client/viewmodel/AnnonceViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.ecodeli.client.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.ecodeli.client.repository.AnnonceRepository
+
+class AnnonceViewModelFactory(private val repo: AnnonceRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(AnnonceViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return AnnonceViewModel(repo) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
## Summary
- create `Annonce` model and repository
- expose `getAnnonces` endpoint in `ApiService`
- implement `AnnonceViewModel` and factory
- create `AnnonceListScreen` and `AnnonceDetailScreen`
- extend navigation with new routes
- provide `AnnonceRepository` via `Injector`

## Testing
- `gradle assembleDebug` *(fails: Could not resolve artifacts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6875576ac54c8331802103e22f2326b2